### PR TITLE
fix(upload): use writable data volume and increase body size limit

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,17 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    // output: 'standalone',
-    typescript: {
-        ignoreBuildErrors: true,
+  // output: 'standalone',
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "4mb",
     },
-    eslint: {
-        ignoreDuringBuilds: true,
-    },
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Fixes file upload failure in production Docker environment by using the mounted /data volume for audit logs and handling write errors gracefully. Also increases Next.js server actions body size limit to 4MB.