### PR TITLE
fix: force start date render in charts

### DIFF
--- a/src/components/ReportDetailView.tsx
+++ b/src/components/ReportDetailView.tsx
@@ -603,6 +603,7 @@ export default function ReportDetailView({
                                             <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f3f4f6" />
                                             <XAxis
                                                 dataKey="date"
+                                                interval="preserveStartEnd"
                                                 tickFormatter={(date) => {
                                                     const d = new Date(date);
                                                     return `${d.getDate()} ${d.toLocaleString('es-ES', { month: 'short' }).substring(0, 3)}`;
@@ -655,6 +656,7 @@ export default function ReportDetailView({
                                             <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f3f4f6" />
                                             <XAxis
                                                 dataKey="date"
+                                                interval="preserveStartEnd"
                                                 tickFormatter={(date) => {
                                                     const d = new Date(date);
                                                     return `${d.getDate()} ${d.toLocaleString('es-ES', { month: 'short' }).substring(0, 3)}`;


### PR DESCRIPTION
Resolves #74

In Recharts AreaCharts, the `<XAxis>` occasionally hides the very first or last tick string (like the first chronoglical date on the left) if it estimates that it might crowd the margin edges. 

By passing the newly added prop `interval="preserveStartEnd"`, we strictly force the chart renderer to always paint the leftmost first measurement date regardless of spacing, ensuring you always know the exact start date of the timeline.