### PR TITLE
fix: remove redundant hover tooltips from charts

### DIFF
--- a/src/components/ReportDetailView.tsx
+++ b/src/components/ReportDetailView.tsx
@@ -613,7 +613,6 @@ export default function ReportDetailView({
                                                 dy={10}
                                             />
                                             <YAxis domain={['dataMin - 0.5', 'dataMax + 0.5']} hide />
-                                            <RechartsTooltip content={<CustomChartTooltip unit="kg" />} />
                                             <Area
                                                 type="monotone"
                                                 dataKey="muscleMass"
@@ -665,7 +664,6 @@ export default function ReportDetailView({
                                                 dy={10}
                                             />
                                             <YAxis domain={['dataMin - 1', 'dataMax + 1']} hide />
-                                            <RechartsTooltip content={<CustomChartTooltip unit="%" />} />
                                             <Area
                                                 type="monotone"
                                                 dataKey="fatPercent"


### PR DESCRIPTION
Resolves #76

Now that we have static data labels (exact values) on the chart points and dates on the X-axis, the hover tooltip provided redundant information. 

Removing it cleans up the user interface and provides a more focused, "dashboard-ready" aesthetic where all key information is instantly readable without user interaction.