### PR TITLE
fix: disable all chart hover effects and animations

### DIFF
--- a/src/components/ReportDetailView.tsx
+++ b/src/components/ReportDetailView.tsx
@@ -603,6 +603,7 @@ export default function ReportDetailView({
                                             <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f3f4f6" />
                                             <XAxis
                                                 dataKey="date"
+                                                interval="preserveStartEnd"
                                                 tickFormatter={(date) => {
                                                     const d = new Date(date);
                                                     return `${d.getDate()} ${d.toLocaleString('es-ES', { month: 'short' }).substring(0, 3)}`;
@@ -613,16 +614,16 @@ export default function ReportDetailView({
                                                 dy={10}
                                             />
                                             <YAxis domain={['dataMin - 0.5', 'dataMax + 0.5']} hide />
-                                            <RechartsTooltip content={<CustomChartTooltip unit="kg" />} />
                                             <Area
                                                 type="monotone"
                                                 dataKey="muscleMass"
+                                                isAnimationActive={false}
                                                 stroke="#10b981"
                                                 strokeWidth={3}
                                                 fillOpacity={1}
                                                 fill="url(#colorMuscle)"
                                                 dot={{ r: 4, fill: '#10b981', strokeWidth: 2, stroke: '#fff' }}
-                                                activeDot={{ r: 6, strokeWidth: 0 }}
+                                                activeDot={false}
                                             >
                                                 <LabelList
                                                     dataKey="muscleMass"
@@ -655,6 +656,7 @@ export default function ReportDetailView({
                                             <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f3f4f6" />
                                             <XAxis
                                                 dataKey="date"
+                                                interval="preserveStartEnd"
                                                 tickFormatter={(date) => {
                                                     const d = new Date(date);
                                                     return `${d.getDate()} ${d.toLocaleString('es-ES', { month: 'short' }).substring(0, 3)}`;
@@ -665,16 +667,16 @@ export default function ReportDetailView({
                                                 dy={10}
                                             />
                                             <YAxis domain={['dataMin - 1', 'dataMax + 1']} hide />
-                                            <RechartsTooltip content={<CustomChartTooltip unit="%" />} />
                                             <Area
                                                 type="monotone"
                                                 dataKey="fatPercent"
+                                                isAnimationActive={false}
                                                 stroke="#eab308"
                                                 strokeWidth={3}
                                                 fillOpacity={1}
                                                 fill="url(#colorFat)"
                                                 dot={{ r: 4, fill: '#eab308', strokeWidth: 2, stroke: '#fff' }}
-                                                activeDot={{ r: 6, strokeWidth: 0 }}
+                                                activeDot={false}
                                             >
                                                 <LabelList
                                                     dataKey="fatPercent"


### PR DESCRIPTION
Resolves #80

This PR implements the requested "completely static" look for the evolutionary charts:
1. **Disabled `activeDot`**: Set `activeDot={false}` to remove any visual change or circle expansion when hovering over data points.
2. **Disabled `isAnimationActive`**: Set to `false` on the Area component to remove all entry animations.
3. **Forced Baseline Date**: Ensured `interval="preserveStartEnd"` is added to the X-Axis so the first measure date is always visible.
4. **No Tooltips**: Confirmed `RechartsTooltip` is removed.

The charts are now purely visual, with no interactive hover animations or loading movement.