### PR TITLE
fix: limit charts to last 5 records and final polish

### DIFF
--- a/src/components/ReportDetailView.tsx
+++ b/src/components/ReportDetailView.tsx
@@ -591,7 +591,7 @@ export default function ReportDetailView({
                                 <div className="h-40">
                                     <ResponsiveContainer width="100%" height="100%">
                                         <AreaChart
-                                            data={[...history].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()).slice(-10)}
+                                            data={[...history].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()).slice(-5)}
                                             margin={{ top: 25, right: 15, left: 15, bottom: 5 }}
                                         >
                                             <defs>
@@ -603,6 +603,7 @@ export default function ReportDetailView({
                                             <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f3f4f6" />
                                             <XAxis
                                                 dataKey="date"
+                                                interval="preserveStartEnd"
                                                 tickFormatter={(date) => {
                                                     const d = new Date(date);
                                                     return `${d.getDate()} ${d.toLocaleString('es-ES', { month: 'short' }).substring(0, 3)}`;
@@ -613,16 +614,16 @@ export default function ReportDetailView({
                                                 dy={10}
                                             />
                                             <YAxis domain={['dataMin - 0.5', 'dataMax + 0.5']} hide />
-                                            <RechartsTooltip content={<CustomChartTooltip unit="kg" />} />
                                             <Area
                                                 type="monotone"
                                                 dataKey="muscleMass"
+                                                isAnimationActive={false}
                                                 stroke="#10b981"
                                                 strokeWidth={3}
                                                 fillOpacity={1}
                                                 fill="url(#colorMuscle)"
                                                 dot={{ r: 4, fill: '#10b981', strokeWidth: 2, stroke: '#fff' }}
-                                                activeDot={{ r: 6, strokeWidth: 0 }}
+                                                activeDot={false}
                                             >
                                                 <LabelList
                                                     dataKey="muscleMass"
@@ -643,7 +644,7 @@ export default function ReportDetailView({
                                 <div className="h-40">
                                     <ResponsiveContainer width="100%" height="100%">
                                         <AreaChart
-                                            data={[...history].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()).slice(-10)}
+                                            data={[...history].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()).slice(-5)}
                                             margin={{ top: 25, right: 15, left: 15, bottom: 5 }}
                                         >
                                             <defs>
@@ -655,6 +656,7 @@ export default function ReportDetailView({
                                             <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f3f4f6" />
                                             <XAxis
                                                 dataKey="date"
+                                                interval="preserveStartEnd"
                                                 tickFormatter={(date) => {
                                                     const d = new Date(date);
                                                     return `${d.getDate()} ${d.toLocaleString('es-ES', { month: 'short' }).substring(0, 3)}`;
@@ -665,16 +667,16 @@ export default function ReportDetailView({
                                                 dy={10}
                                             />
                                             <YAxis domain={['dataMin - 1', 'dataMax + 1']} hide />
-                                            <RechartsTooltip content={<CustomChartTooltip unit="%" />} />
                                             <Area
                                                 type="monotone"
                                                 dataKey="fatPercent"
+                                                isAnimationActive={false}
                                                 stroke="#eab308"
                                                 strokeWidth={3}
                                                 fillOpacity={1}
                                                 fill="url(#colorFat)"
                                                 dot={{ r: 4, fill: '#eab308', strokeWidth: 2, stroke: '#fff' }}
-                                                activeDot={{ r: 6, strokeWidth: 0 }}
+                                                activeDot={false}
                                             >
                                                 <LabelList
                                                     dataKey="fatPercent"


### PR DESCRIPTION
Resolves #82

This PR updates the data visibility logic for the evolutionary health charts:
1. **Show Graph Condition**: The chart remains visible only if 2 or more historical records exist (`history.length >= 2`).
2. **Data Limit**: The chart now strictly displays only the **last 5 records** (`slice(-5)`) instead of 10.
3. **Persisted Polishing**: Re-enforces no animations, no hover tooltips, no `activeDot` effects, and forced baseline date visibility.

This ensures the user sees only the most recent progress in a clean, static, and focused view.