### PR TITLE
Fix production deployment by forcing git sync on Raspberry Pi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           key: ${{ secrets.PI_SSH_KEY }}
           script: |
             cd /home/judithvsanchezc/Desktop/dev/martas-health-lab
-            git pull origin main
+            git fetch origin main
+            git reset --hard origin/main
             docker compose build
             docker compose up -d


### PR DESCRIPTION
This PR fixes the production deployment issue on the Raspberry Pi by using a more robust `git reset --hard` strategy. 

The previous `git pull origin main` was failing with `fatal: Need to specify how to reconcile divergent branches`, which prevented any of today's changes from actually going live. 

Once merged, the CI will force a sync on the Pi and restart the containers with all recent layout and PDF fixes.