### PR TITLE
Make Tailscale deployment safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   quality-checks:
     runs-on: ubuntu-latest
@@ -52,24 +55,52 @@ jobs:
     needs: quality-checks
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v3
+        uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:ci
+          ping: ${{ secrets.PI_HOST }}
 
       - name: Deploy to Raspberry Pi
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.PI_HOST }}
           username: ${{ secrets.PI_USERNAME }}
           key: ${{ secrets.PI_SSH_KEY }}
           script: |
-            cd /home/judithvsanchezc/Desktop/dev/martas-health-lab
+            set -eu
+
+            repo=/home/judithvsanchezc/Desktop/dev/martas-health-lab
+            cd "$repo"
+
+            # Preserve the live SQLite database before replacing the app.
+            backup_name="prod-$(date -u +%Y%m%dT%H%M%SZ).db"
+            docker exec martas-lab mkdir -p /app/data/backups
+            docker exec \
+              -e BACKUP_FILE="/app/data/backups/$backup_name" \
+              martas-lab \
+              node -e 'const Database = require("better-sqlite3"); const db = new Database("/app/data/prod.db"); db.backup(process.env.BACKUP_FILE).then(() => db.close()).catch((error) => { console.error(error); process.exit(1); });'
+
+            # Build from origin/main without modifying the dirty live worktree.
             git fetch origin main
-            git reset --hard origin/main
-            docker compose build
-            docker compose up -d
+            previous_image="$(docker inspect --format '{{.Image}}' martas-lab)"
+            docker image tag "$previous_image" martas-health-lab-app:rollback
+            git archive --format=tar origin/main | docker build --tag martas-health-lab-app:candidate -
+            docker image tag martas-health-lab-app:candidate martas-health-lab-app:latest
+
+            # Keep the existing ./data mount and automatically restore the old
+            # image if the new container does not become healthy.
+            if ! docker compose up -d --no-build --wait --wait-timeout 90 app; then
+              docker image tag martas-health-lab-app:rollback martas-health-lab-app:latest
+              docker compose up -d --no-build --wait --wait-timeout 90 app
+              exit 1
+            fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,13 @@ services:
     environment:
       - DATABASE_URL=file:/app/data/prod.db
       - NEXT_PUBLIC_APP_URL=http://localhost:3000
-    # healthcheck:
-    #   test: ["CMD", "curl", "-f", "http://localhost:3000"]
-    #   interval: 30s
-    #   timeout: 10s
-    #   retries: 3
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://127.0.0.1:3000').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s


### PR DESCRIPTION
## What changed

- upgrades the Tailscale GitHub Action from v3 to v4 and prepares workload identity federation using `TS_OAUTH_CLIENT_ID` and `TS_AUDIENCE`
- gives the deploy job only `contents: read` and `id-token: write`
- pins the SSH action to v1.2.5 instead of `master`
- removes the destructive `git reset --hard` deployment
- builds the image from `origin/main` without modifying the live Raspberry Pi worktree
- creates an online SQLite backup before replacement
- preserves the existing `./data` database mount
- adds an application health check and automatically rolls back to the previous image if startup fails

## Why

The live Pi checkout contains local changes, while the current deployment force-resets it. The persistent Tailscale auth key also leaves stale `github-runnervm…` devices in the tailnet. This change makes deployments reversible and prepares ephemeral CI authentication.

## User impact

The existing Marta endpoint and database location remain unchanged. The workflow will not be ready to merge until the Tailscale federated identity secrets and `tag:ci` grant are configured.

## Validation

- YAML parsed successfully
- `docker compose config --quiet` succeeded on the Raspberry Pi with Docker Compose v2.37.3
- diff whitespace validation succeeded
- no application test framework was added or run

## Before merge

1. Create a Tailscale federated identity for `tag:ci`.
2. Add repository secrets `TS_OAUTH_CLIENT_ID` and `TS_AUDIENCE`.
3. Grant `tag:ci` TCP/22 access to the Pi deployment identity.
4. Prefer setting `PI_HOST` to the native `pricespy` Tailscale address so restarting `ha-pi` cannot interrupt deployment SSH.
