### PR TITLE
Use durable Tailscale OAuth for production deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v3
+        uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+          tags: tag:ci
+          ping: ${{ secrets.PI_HOST }}
 
       - name: Deploy to Raspberry Pi
         uses: appleboy/ssh-action@v1.2.5


### PR DESCRIPTION
## What changed

- upgrade the Tailscale GitHub Action from v3 to v4
- authenticate through a least-privilege OAuth client restricted to `auth_keys` and `tag:ci`
- ping the configured Raspberry Pi before starting SSH

## Why

The previous production run exhausted retries while using the old auth key, then continued to the SSH step and timed out. The OAuth client avoids expiring reusable auth-key maintenance, while the explicit ping fails the connection step before deployment if the Pi is unreachable.

## Impact

Pushes to `main` continue to deploy production after quality checks. The deployment still preserves its database backup, health check, rollback image, and scoped cleanup behavior.

## Validation

- `git diff --check`
- confirmed the OAuth client ID and secret exist as GitHub Actions secrets
- confirmed the OAuth client has only `auth_keys` access with the existing `tag:ci`

Per repository instructions, no application tests were run locally.