### PR TITLE
Prune production build cache immediately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,15 +85,15 @@ jobs:
 
             cleanup() {
               rm -f "$compose_file"
-              docker builder prune --force --filter "until=2h" >/dev/null 2>&1 || true
+              docker builder prune --force >/dev/null 2>&1 || true
             }
             trap cleanup EXIT
 
             cd "$repo"
             git fetch origin main
 
-            # Reclaim expired build cache before measuring deployment headroom.
-            docker builder prune --force --filter "until=2h" >/dev/null 2>&1 || true
+            # Reclaim disposable build cache before measuring deployment headroom.
+            docker builder prune --force >/dev/null 2>&1 || true
 
             # Build only when the Pi has enough non-reserved space to complete
             # the image alongside the currently running rollback candidate.


### PR DESCRIPTION
## What changed

- prune all disposable Docker build cache before checking deployment headroom
- prune all disposable Docker build cache again when deployment exits

## Why

The successful slim-image deployment left the newly-created BuildKit cache because cleanup only removed entries older than two hours. The Pi finished at 94% disk usage and would have failed the next deployment before that cache aged out.

## Impact

Production keeps the active image, one rollback image, the SQLite database, and its pre-deploy backup. Only rebuildable Docker build cache is removed. Builds may take longer because dependencies are rebuilt each time, which is the appropriate tradeoff for this 29 GB Raspberry Pi.

## Validation

- `git diff --check`
- observed the successful deployment finish at 94% disk usage with the new cache still present

Per repository instructions, no application tests were run locally.