### PR TITLE
Fix production database write permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,18 +50,18 @@ ENV NODE_ENV=production \
     HOSTNAME=0.0.0.0 \
     PORT=3000
 
-RUN addgroup --system --gid 1001 nodejs \
-    && adduser --system --uid 1001 --ingroup nodejs nextjs \
-    && mkdir -p /app/data /app/scripts \
-    && chown -R nextjs:nodejs /app
+# The base image's non-root node account is UID/GID 1000, matching the Pi host
+# account that owns the bind-mounted production database.
+RUN mkdir -p /app/data /app/scripts \
+    && chown -R node:node /app
 
 # Next standalone output contains only traced production dependencies. The
 # database upgrade script remains an explicit startup prerequisite.
-COPY --chown=nextjs:nodejs --from=builder /app/.next/standalone ./
-COPY --chown=nextjs:nodejs --from=builder /app/.next/static ./.next/static
-COPY --chown=nextjs:nodejs --from=builder /app/scripts/db-upgrade.js ./scripts/db-upgrade.js
+COPY --chown=node:node --from=builder /app/.next/standalone ./
+COPY --chown=node:node --from=builder /app/.next/static ./.next/static
+COPY --chown=node:node --from=builder /app/scripts/db-upgrade.js ./scripts/db-upgrade.js
 
-USER nextjs
+USER node
 
 EXPOSE 3000
 

--- a/deployment/docker-compose.override.pi.yml
+++ b/deployment/docker-compose.override.pi.yml
@@ -1,0 +1,5 @@
+# Raspberry Pi production identity override.
+# Keep the container aligned with the host account that owns restored SSD data.
+services:
+  app:
+    user: "1000:1000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: Dockerfile
     container_name: martas-lab
     init: true
+    # Match the Raspberry Pi host user so restored bind-mounted data stays writable.
+    user: "1000:1000"
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/scripts/db-upgrade.js
+++ b/scripts/db-upgrade.js
@@ -20,6 +20,23 @@ if (!fs.existsSync(dir)) {
 try {
   const db = new Database(dbPath, { timeout: 8000 });
 
+  // Prove the main database is writable without retaining any probe data.
+  // SQLite DDL is transactional, so ROLLBACK removes the temporary table/row.
+  try {
+    db.exec(`
+      BEGIN IMMEDIATE;
+      CREATE TABLE IF NOT EXISTS __marta_write_probe (id INTEGER);
+      INSERT INTO __marta_write_probe (id) VALUES (1);
+      ROLLBACK;
+    `);
+    console.log("[DB Upgrade] Database write check passed.");
+  } catch (writeError) {
+    if (db.inTransaction) {
+      db.exec("ROLLBACK;");
+    }
+    throw new Error(`Database is not writable: ${writeError.message}`);
+  }
+
   // Create system_logs table if missing
   db.exec(`
     CREATE TABLE IF NOT EXISTS system_logs (
@@ -56,4 +73,5 @@ try {
   console.log("[DB Upgrade] Database schema check completed successfully.");
 } catch (error) {
   console.error("[DB Upgrade] Failed to access or upgrade database:", error);
+  process.exitCode = 1;
 }

--- a/src/components/CsvUploadFlow.tsx
+++ b/src/components/CsvUploadFlow.tsx
@@ -23,6 +23,7 @@ export default function CsvUploadFlow({ preselectedClientId }: { preselectedClie
 
     // Real-time recalculation for a specific assignment
     const recalculateRecord = (record: any, client: any) => {
+        const hasValue = (value: any) => value !== undefined && value !== null && value !== "";
         const w = parseFloat(record.weight);
         const h = parseFloat(record.height) || client?.height;
         const f = parseFloat(record.fatPercent);
@@ -36,9 +37,9 @@ export default function CsvUploadFlow({ preselectedClientId }: { preselectedClie
             updates.bmi = parseFloat((w / ((h / 100) ** 2)).toFixed(1));
         }
 
-        // 2. Bone Mass (Heuristic)
+        // 2. Bone Mass (Heuristic fallback only)
         let currentBone = parseFloat(record.boneMass);
-        if (!isNaN(w)) {
+        if (!hasValue(record.boneMass) && !isNaN(w)) {
             if (gender === 'female') {
                 if (w < 50) currentBone = 1.95;
                 else if (w <= 75) currentBone = 2.40;
@@ -51,8 +52,8 @@ export default function CsvUploadFlow({ preselectedClientId }: { preselectedClie
             updates.boneMass = currentBone;
         }
 
-        // 3. Muscle Mass
-        if (!isNaN(w) && !isNaN(f) && !isNaN(currentBone)) {
+        // 3. Muscle Mass fallback
+        if (!hasValue(record.muscleMass) && !isNaN(w) && !isNaN(f) && !isNaN(currentBone)) {
             const fatMass = w * (f / 100);
             updates.muscleMass = parseFloat((w - fatMass - currentBone).toFixed(2));
         }
@@ -62,8 +63,8 @@ export default function CsvUploadFlow({ preselectedClientId }: { preselectedClie
             updates.bmr = calculateBMR(w, h, age, gender).value;
         }
 
-        // 5. Metabolic Age
-        if (!isNaN(f) && !isNaN(age)) {
+        // 5. Metabolic Age fallback
+        if (!hasValue(record.metabolicAge) && !isNaN(f) && !isNaN(age)) {
             const targetFat = gender === 'female' ? 23 : 15;
             let metAge = age + (f - targetFat) * 0.5;
             metAge = Math.max(12, Math.min(age + 15, Math.max(age - 15, metAge)));
@@ -146,10 +147,15 @@ export default function CsvUploadFlow({ preselectedClientId }: { preselectedClie
                 throw new Error("Por favor asigne todas las filas a un cliente o registre uno nuevo.");
             }
 
-            await persistPerRowAssignments(assignments);
+            const result = await persistPerRowAssignments(assignments);
+            if (!result.success) {
+                setError(result.message);
+                return;
+            }
+
             setStep("success");
-        } catch (err: any) {
-            setError(err.message || "Error al guardar los datos");
+        } catch {
+            setError("No se pudo conectar con el servidor para guardar los datos. No se guardó ninguna medición. Comprueba la conexión VPN e inténtalo de nuevo.");
         } finally {
             setLoading(false);
         }

--- a/src/components/RecordForm.tsx
+++ b/src/components/RecordForm.tsx
@@ -48,6 +48,7 @@ export function RecordForm({ clientId, client, record, onClose, onSuccess }: Rec
 
     // Real-time recalculation
     useEffect(() => {
+        const hasValue = (value: string) => value !== "";
         const w = parseFloat(formData.weight);
         const h = parseFloat(formData.height);
         const f = parseFloat(formData.fatPercent);
@@ -61,9 +62,9 @@ export function RecordForm({ clientId, client, record, onClose, onSuccess }: Rec
             updates.bmi = (w / ((h / 100) ** 2)).toFixed(1);
         }
 
-        // 2. Bone Mass (Heuristic if not present)
+        // 2. Bone Mass (Heuristic fallback only)
         let currentBone = parseFloat(formData.boneMass);
-        if (!isNaN(w)) {
+        if (!hasValue(formData.boneMass) && !isNaN(w)) {
             if (gender === 'female') {
                 if (w < 50) currentBone = 1.95;
                 else if (w <= 75) currentBone = 2.40;
@@ -76,8 +77,8 @@ export function RecordForm({ clientId, client, record, onClose, onSuccess }: Rec
             updates.boneMass = currentBone.toString();
         }
 
-        // 3. Muscle Mass (Weight - FatMass - BoneMass)
-        if (!isNaN(w) && !isNaN(f) && !isNaN(currentBone)) {
+        // 3. Muscle Mass fallback (Weight - FatMass - BoneMass)
+        if (!hasValue(formData.muscleMass) && !isNaN(w) && !isNaN(f) && !isNaN(currentBone)) {
             const fatMass = w * (f / 100);
             updates.muscleMass = (w - fatMass - currentBone).toFixed(2);
         }
@@ -87,8 +88,8 @@ export function RecordForm({ clientId, client, record, onClose, onSuccess }: Rec
             updates.bmr = calculateBMR(w, h, age, gender).value.toString();
         }
 
-        // 5. Metabolic Age
-        if (!isNaN(f) && !isNaN(age)) {
+        // 5. Metabolic Age fallback
+        if (!hasValue(formData.metabolicAge) && !isNaN(f) && !isNaN(age)) {
             const targetFat = gender === 'female' ? 23 : 15;
             let metAge = age + (f - targetFat) * 0.5;
             // Bounds check same as backend logic
@@ -100,7 +101,7 @@ export function RecordForm({ clientId, client, record, onClose, onSuccess }: Rec
             setFormData(prev => ({ ...prev, ...updates }));
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [formData.weight, formData.height, formData.fatPercent, client]);
+    }, [formData.weight, formData.height, formData.fatPercent, formData.boneMass, formData.muscleMass, formData.metabolicAge, client]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target;

--- a/src/components/__tests__/CsvUploadFlow.test.tsx
+++ b/src/components/__tests__/CsvUploadFlow.test.tsx
@@ -141,7 +141,7 @@ describe("CsvUploadFlow", () => {
             data: [{ number: "100", age: "40" }],
             message: "Success"
         });
-        (persistActions.persistPerRowAssignments as any).mockResolvedValue(undefined);
+        (persistActions.persistPerRowAssignments as any).mockResolvedValue({ success: true, count: 1 });
 
         render(<CsvUploadFlow />);
 

--- a/src/lib/actions/persist-csv.ts
+++ b/src/lib/actions/persist-csv.ts
@@ -16,7 +16,11 @@ export type RowAssignment = {
     };
 };
 
-export async function persistPerRowAssignments(assignments: RowAssignment[]) {
+export type PersistAssignmentsResult =
+    | { success: true; count: number }
+    | { success: false; code: "DATABASE_READ_ONLY" | "DATABASE_SAVE_FAILED"; message: string };
+
+export async function persistPerRowAssignments(assignments: RowAssignment[]): Promise<PersistAssignmentsResult> {
     try {
         await logger.info(`Starting persistence for ${assignments.length} assignments`, null, "DB_PERSIST");
 
@@ -80,8 +84,22 @@ export async function persistPerRowAssignments(assignments: RowAssignment[]) {
 
         await logger.success(`Successfully persisted ${assignments.length} assignments`, { count: assignments.length }, "DB_PERSIST");
         revalidatePath("/");
+        return { success: true, count: assignments.length };
     } catch (error: any) {
         await logger.error(`Persistence error: ${error.message}`, { error: error.stack }, "DB_PERSIST");
-        throw error;
+
+        if (error?.code === "SQLITE_READONLY" || error?.message?.includes("readonly database")) {
+            return {
+                success: false,
+                code: "DATABASE_READ_ONLY",
+                message: "El archivo se procesó correctamente, pero la base de datos no tiene permisos de escritura. No se guardó ninguna medición. Contacta con soporte antes de volver a intentarlo.",
+            };
+        }
+
+        return {
+            success: false,
+            code: "DATABASE_SAVE_FAILED",
+            message: "El archivo se procesó correctamente, pero ocurrió un error al guardar. No se guardó ninguna medición. Contacta con soporte antes de volver a intentarlo.",
+        };
     }
 }


### PR DESCRIPTION
## Summary
- align the production container with the Raspberry Pi host UID/GID so the SSD-backed SQLite database remains writable
- fail startup when SQLite cannot acquire a write transaction
- return clear Spanish save errors instead of Next.js production redactions
- preserve imported Tanita metrics instead of recalculating values that are already present

## Production safety
- a verified database backup was created on the Pi microSD before changing permissions
- the live database integrity check passes and row counts were unchanged after the operational repair
- no schema migration or data rewrite is included